### PR TITLE
remove spaces in SYMFONY_APP_PATH

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # Symfony
-SYMFONY_APP_PATH = ../application
+SYMFONY_APP_PATH=../application
 
 # MySQL
 MYSQL_ROOT_PASSWORD=root


### PR DESCRIPTION
Docker fails to start with "SYMFONY_APP_PATH = ../application" Removing spaces all runs fine (SYMFONY_APP_PATH=../application)