### PR TITLE
xDebug support and php-fpm override bugfix

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,6 @@ MYSQL_DATABASE=db
 MYSQL_USER=user
 MYSQL_PASSWORD=password
 
-
-
-
+# xDebug
+XDEBUG_REMOTE_ENABLE=0
+XDEBUG_REMOTE_HOST=your-local-ip

--- a/README.md
+++ b/README.md
@@ -17,6 +17,33 @@ Complete stack run with docker and [docker-compose](https://docs.docker.com/comp
     $ docker-compose up -d
     ```
 
+## Activate xDebug
+
+Open your .env and find
+
+```
+# xDebug
+XDEBUG_REMOTE_ENABLE=0
+XDEBUG_REMOTE_HOST=your-local-ip
+```
+
+Change ```XDEBUG_REMOTE_ENABLE=0``` to ```XDEBUG_REMOTE_ENABLE=1``` and ```your-local-ip```
+with the local IP of your computer, in my case ```192.168.0.12```. The result is something like:
+
+```
+# xDebug
+XDEBUG_REMOTE_ENABLE=1
+XDEBUG_REMOTE_HOST=192.168.0.12
+```
+
+
+Restart the php-fpm container:
+
+```bash
+$ docker stop php-fpm
+$ docker-compose up -d
+```
+
 ## Useful commands
 
 ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ services:
       container_name: php-webserver
       volumes:
           - ../infrastructure/nginx/nginx.conf:/etc/nginx/conf.d/default.conf
+          - ${SYMFONY_APP_PATH}:/application
       ports:
        - "8080:80"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       container_name: php-fpm
       volumes:
         - ${SYMFONY_APP_PATH}:/application
-        - ../infrastructure/php-fpm/php-ini-overrides.ini:/etc/php/7.2/fpm/conf.d/99-overrides.ini
+        - ../infrastructure/php-fpm/php-ini-overrides.ini:/usr/local/etc/php/conf.d/infrastructure-overrides.ini
         - ./var:/application/var
         - ../application:/application
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,8 @@ services:
         - ../infrastructure/php-fpm/php-ini-overrides.ini:/usr/local/etc/php/conf.d/infrastructure-overrides.ini
         - ./var:/application/var
         - ../application:/application
+      environment:
+        XDEBUG_CONFIG: remote_host=${XDEBUG_REMOTE_HOST} remote_enable=${XDEBUG_REMOTE_ENABLE}
 
     phpmyadmin:
         image: phpmyadmin/phpmyadmin

--- a/php-fpm/Dockerfile
+++ b/php-fpm/Dockerfile
@@ -21,6 +21,10 @@ RUN curl -L -o /tmp/redis.tar.gz https://github.com/phpredis/phpredis/archive/3.
     && mv phpredis-3.1.6/* /usr/src/php/ext/redis/ \
     && docker-php-ext-install redis
 
+# install xdebug
+RUN pecl install xdebug \
+    && docker-php-ext-enable xdebug
+
 # Fix permission problems
 RUN usermod -u 1000 www-data 
 


### PR DESCRIPTION
- PHP-FPM: Set the correct container path to override the .ini
- PHP-FPM: Change Dockerfile to install xDebug and docker-compose.yml to add the enviroment to activate the xdebug and the xdebug remote host.