### PR TITLE
Environments, Link MySQL container to run with phpMyAdmin and PHP-FPM and down mysql version to 5.7

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,9 @@
+# Docker environment (|Debug|Blackfire|Apache)
+# Default: Environment with nginx
+# Debug: Environment with xDebug
+# Blackfire: Environment with Blackfire
+DOCKER_ENVIRONMENT=
+
 # Symfony
 SYMFONY_APP_PATH=../application
 
@@ -7,7 +13,13 @@ MYSQL_DATABASE=db
 MYSQL_USER=user
 MYSQL_PASSWORD=password
 
-# xDebug
+# xDebug (debug environment)
 XDEBUG_REMOTE_ENABLE=0
 XDEBUG_REMOTE_HOST=your-local-ip
 XDEBUG_SERVER_NAME=localhost
+
+# Blackfire (blackfire environment)
+BLACKFIRE_CLIENT_ID=YOUR_CLIENT_ID
+BLACKFIRE_CLIENT_TOKEN=YOUR_CLIENT_TOKEN
+BLACKFIRE_SERVER_ID=YOUR_SERVER_ID
+BLACKFIRE_SERVER_TOKEN=YOUR_SERVER_TOKEN

--- a/README.md
+++ b/README.md
@@ -17,6 +17,15 @@ Complete stack run with docker and [docker-compose](https://docs.docker.com/comp
     $ docker-compose up -d
     ```
 
+## Environments
+
+You can configure some environments:
+
+- Normal enviroment (DOCKER_ENVIRONMENT=)
+- Debug enviroment (DOCKER_ENVIRONMENT=Debug)
+- Blackfire environment (DOCKER_ENVIRONMENT=Blackfire)
+- Use Apache instead Nginx (DOCKER_ENVIRONMENT=Apache)
+
 ## Activate xDebug
 
 Open your .env and find
@@ -36,11 +45,17 @@ XDEBUG_REMOTE_ENABLE=1
 XDEBUG_REMOTE_HOST=192.168.0.12
 ```
 
-Restart the php-fpm container:
+Activate de Debug enviroment
+
+```
+DOCKER_ENVIRONMENT=Debug
+```
+
+Restart the php-fpm container forcing the rebuild:
 
 ```bash
 $ docker stop php-fpm
-$ docker-compose up -d
+$ docker-compose up -d --build
 ```
 
 ### Connect phpStorm with xDebug
@@ -91,6 +106,49 @@ Check the pre-configuration steps. When all are OK, go to localhost:8080 in your
 antivate the debug in the Xdebug extension, refresh the webpage and go.
 
 If you change the serverName, you must change the value of ```XDEBUG_SERVER_NAME``` in your .env file
+
+## Activate Blackfire
+
+
+Open your .env and activate the Blackfire environment
+
+```
+DOCKER_ENVIRONMENT=Blackfire
+```
+
+You must be register at https://blackfire.io and go to your credentials page:
+
+https://blackfire.io/my/settings/credentials
+
+Copy the client and server credentials and paste them in the Blackfire section:
+
+```
+# Blackfire (blackfire environment)
+BLACKFIRE_CLIENT_ID=YOUR_CLIENT_ID
+BLACKFIRE_CLIENT_TOKEN=YOUR_CLIENT_TOKEN
+BLACKFIRE_SERVER_ID=YOUR_SERVER_ID
+BLACKFIRE_SERVER_TOKEN=YOUR_SERVER_TOKEN
+```
+
+Restart the php-fpm container forcing the rebuild:
+
+```bash
+$ docker stop php-fpm
+$ docker-compose up -d --build
+```
+
+After the fisrt start in Blackfire mode you must restart the service to register the agent:
+
+```
+$ docker-compose exec php-fpm bash
+$ /etc/init.d/blackfire-agent restart
+```
+
+Now you must install the chrome extension (or firefox if is your browser):
+
+https://chrome.google.com/webstore/detail/blackfire-companion/miefikpgahefdbcgoiicnmpbeeomffld
+
+With this extension installed, you can go to your site (http://localhost:8080) and run the profile easily
 
 ## Useful commands
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Docker example for Symfony4
 
-Complete stack run with docker and [docker-compose](https://docs.docker.com/compose/) with **PHP7.2-FPM - NGINX - MySQL 8** and **REDIS**.
+Complete stack run with docker and [docker-compose](https://docs.docker.com/compose/) with **PHP7.2-FPM - NGINX - MySQL 5.7** and **REDIS**... **Apache2** option available
 
 ## Installation
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,23 +22,31 @@ services:
       image: nginx:alpine
       container_name: php-webserver
       volumes:
-          - ../infrastructure/nginx/nginx.conf:/etc/nginx/conf.d/default.conf
+          - ./nginx/nginx.conf:/etc/nginx/conf.d/default.conf
           - ${SYMFONY_APP_PATH}:/application
       ports:
        - "8080:80"
 
     php-fpm:
-      build: php-fpm
+      image: php-fpm
+      build:
+        context: .
+        dockerfile: php-fpm/Dockerfile${DOCKER_ENVIRONMENT}
       container_name: php-fpm
       volumes:
         - ${SYMFONY_APP_PATH}:/application
-        - ../infrastructure/php-fpm/php-ini-overrides.ini:/usr/local/etc/php/conf.d/infrastructure-overrides.ini
+        - ./php-fpm/php-ini-overrides.ini:/usr/local/etc/php/conf.d/infrastructure-overrides.ini
         - ./var:/application/var
         - ../application:/application
       links:
         - mysql:php-mysql
       environment:
         XDEBUG_CONFIG: remote_host=${XDEBUG_REMOTE_HOST} remote_enable=${XDEBUG_REMOTE_ENABLE}
+        PHP_IDE_CONFIG: serverName=${XDEBUG_SERVER_NAME}
+        BLACKFIRE_CLIENT_ID: ${BLACKFIRE_CLIENT_ID}
+        BLACKFIRE_CLIENT_TOKEN: ${BLACKFIRE_CLIENT_TOKEN}
+        BLACKFIRE_SERVER_ID: ${BLACKFIRE_SERVER_ID}
+        BLACKFIRE_SERVER_TOKEN: ${BLACKFIRE_SERVER_TOKEN}
 
     phpmyadmin:
         image: phpmyadmin/phpmyadmin
@@ -51,3 +59,19 @@ services:
             - PMA_HOST=php-mysql
         links:
             - mysql:php-mysql
+
+    # Alternative PHP:7.2.6 + apache
+    #php:
+    #    build: php
+    #    image: php:7.2.6-apache-stretch
+    #    container_name: php
+    #    volumes:
+    #        - ${SYMFONY_APP_PATH}:/application
+    #        - ./var:/application/var
+    #        - ../application:/application
+    #    links:
+    #        - mysql:php-mysql
+    #    ports:
+    #        - "8083:80"
+
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       container_name: php-redis
 
     mysql:
-      image: mysql:8.0
+      image: mysql:5.7
       container_name: php-mysql
       volumes:
         - "./database:/var/lib/mysql"
@@ -24,6 +24,8 @@ services:
       volumes:
           - ../infrastructure/nginx/nginx.conf:/etc/nginx/conf.d/default.conf
           - ${SYMFONY_APP_PATH}:/application
+      links:
+        - mysql:php-mysql
       ports:
        - "8080:80"
 
@@ -43,3 +45,9 @@ services:
         container_name: phpmyadmin
         ports:
             - "8081:80"
+        environment:
+            - PMA_USER=${MYSQL_USER}
+            - PMA_PASSWORD=${MYSQL_PASSWORD}
+            - PMA_HOST=php-mysql
+        links:
+            - mysql:php-mysql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,8 +24,6 @@ services:
       volumes:
           - ../infrastructure/nginx/nginx.conf:/etc/nginx/conf.d/default.conf
           - ${SYMFONY_APP_PATH}:/application
-      links:
-        - mysql:php-mysql
       ports:
        - "8080:80"
 
@@ -37,6 +35,8 @@ services:
         - ../infrastructure/php-fpm/php-ini-overrides.ini:/usr/local/etc/php/conf.d/infrastructure-overrides.ini
         - ./var:/application/var
         - ../application:/application
+      links:
+        - mysql:php-mysql
       environment:
         XDEBUG_CONFIG: remote_host=${XDEBUG_REMOTE_HOST} remote_enable=${XDEBUG_REMOTE_ENABLE}
 

--- a/php-fpm/Dockerfile
+++ b/php-fpm/Dockerfile
@@ -19,6 +19,11 @@ RUN apt-get update && \
     zlib1g-dev \
     && docker-php-ext-install zip
 
+# Install mysql
+RUN docker-php-ext-install mysqli
+
+RUN apt-get update && apt-get install -y mysql-client && rm -rf /var/lib/apt
+
 # install gd mbstring pdo
 RUN apt-get update && apt-get install -y libpng-dev libjpeg-dev libpq-dev \
  	&& rm -rf /var/lib/apt/lists/* \

--- a/php-fpm/DockerfileBlackfire
+++ b/php-fpm/DockerfileBlackfire
@@ -38,8 +38,39 @@ RUN curl -L -o /tmp/redis.tar.gz https://github.com/phpredis/phpredis/archive/3.
     && mv phpredis-3.1.6/* /usr/src/php/ext/redis/ \
     && docker-php-ext-install redis
 
+# install blackfire
+ENV BLACKFIRE_LOG_LEVEL 1
+ENV BLACKFIRE_LOG_FILE /var/log/blackfire/blackfire.log
+ENV BLACKFIRE_SOCKET unix:///var/run/blackfire/agent.sock
+
+RUN apt-get update && apt-get install -y wget gnupg
+
+RUN wget -O - https://packagecloud.io/gpg.key | apt-key add - && \
+    echo "deb http://packages.blackfire.io/debian any main" | tee /etc/apt/sources.list.d/blackfire.list
+
+RUN apt-get update && \
+    apt-get install -y \
+    blackfire-agent \
+    blackfire-php
+
+RUN \
+    version=$(php -r "echo PHP_MAJOR_VERSION, PHP_MINOR_VERSION;") \
+    && curl -A "Docker" -o /tmp/blackfire-probe.tar.gz -D - -L -s https://blackfire.io/api/v1/releases/probe/php/linux/amd64/${version} \
+    && tar zxpf /tmp/blackfire-probe.tar.gz -C /tmp \
+    && mv /tmp/blackfire-*.so $(php -r "echo ini_get('extension_dir');")/blackfire.so
+
+COPY php-fpm/blackfire-agent.ini /etc/blackfire/agent
+COPY php-fpm/blackfire-php.ini /usr/local/etc/php/conf.d/92-blackfire-config.ini
+COPY php-fpm/blackfire-php.ini /usr/local/etc/php/conf.d/92-blackfire-config.ini
+COPY php-fpm/blackfire-run.sh /blackfire-run.sh
+
+RUN /etc/init.d/blackfire-agent restart
+
 # Fix permission problems
 RUN usermod -u 1000 www-data 
 
 RUN echo 'alias ll="ls -l"' >> ~/.bashrc
 RUN echo 'alias sf="php bin/console"' >> ~/.bashrc
+
+# ENTRYPOINT ["/bin/bash", "/blackfire-run.sh"]
+

--- a/php-fpm/DockerfileDebug
+++ b/php-fpm/DockerfileDebug
@@ -38,6 +38,10 @@ RUN curl -L -o /tmp/redis.tar.gz https://github.com/phpredis/phpredis/archive/3.
     && mv phpredis-3.1.6/* /usr/src/php/ext/redis/ \
     && docker-php-ext-install redis
 
+# install xdebug
+RUN pecl install xdebug \
+    && docker-php-ext-enable xdebug
+
 # Fix permission problems
 RUN usermod -u 1000 www-data 
 

--- a/php-fpm/blackfire-agent.ini
+++ b/php-fpm/blackfire-agent.ini
@@ -1,0 +1,66 @@
+[blackfire]
+;
+; This is a configuration file for Blackfire's Agent.
+;
+
+;
+; setting: ca-cert
+; desc   : Sets the PEM encoded certificates
+; default: 
+ca-cert=
+
+;
+; setting: collector
+; desc   : Sets the URL of Blackfire's data collector
+; default: https://blackfire.io
+collector=https://blackfire.io
+
+;
+; setting: http-proxy
+; desc   : Sets the HTTP proxy to use
+; default: 
+http-proxy=
+
+;
+; setting: https-proxy
+; desc   : Sets the HTTPS proxy to use
+; default: 
+https-proxy=
+
+;
+; setting: log-file
+; desc   : Sets the path of the log file. Use stderr to log to stderr
+; default: stderr
+log-file=/var/log/blackfire/blackfire.log
+
+;
+; setting: log-level
+; desc   : log verbosity level (4: debug, 3: info, 2: warning, 1: error)
+; default: 1
+log-level=1
+
+;
+; setting: server-id
+; desc   : Sets the server id used to authenticate with Blackfire API
+; default: 
+server-id=
+
+;
+; setting: server-token
+; desc   : Sets the server token used to authenticate with Blackfire API. It is unsafe to set this from the command line
+; default: 
+server-token=
+
+;
+; setting: socket
+; desc   : Sets the socket the agent should read traces from. Possible value can be a unix socket or a TCP address. ie: unix:///var/run/blackfire/agent.sock or tcp://127.0.0.1:8307
+; default: unix:///var/run/blackfire/agent.sock
+socket=unix:///var/run/blackfire/agent.sock
+
+;
+; setting: spec
+; desc   : Sets the path to the JSON specifications file
+; default: 
+spec=
+
+

--- a/php-fpm/blackfire-php.ini
+++ b/php-fpm/blackfire-php.ini
@@ -1,0 +1,5 @@
+blackfire.agent_socket=unix:///var/run/blackfire/agent.sock
+blackfire.log_file=/var/log/blackfire/blackfire.log
+blackfire.log_level=4
+blackfire.server_id=
+blackfire.server_token=

--- a/php-fpm/blackfire-run.sh
+++ b/php-fpm/blackfire-run.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+variables=( "BLACKFIRE_SERVER_ID" "BLACKFIRE_SERVER_TOKEN" "BLACKFIRE_CLIENT_ID" "BLACKFIRE_CLIENT_TOKEN" "BLACKFIRE_SOCKET" "BLACKFIRE_LOG_LEVEL" "BLACKFIRE_LOG_FILE")
+
+for var in "${variables[@]}"
+do
+   :
+   sed -i "s|%$var%|${!var}|g" /etc/blackfire/agent
+   sed -i "s|%$var%|${!var}|g" /usr/local/etc/php/conf.d/92-blackfire-config.ini
+   sed -i "s|%$var%|${!var}|g" /usr/local/etc/php/conf.d/92-blackfire-config.ini
+done
+
+blackfire-agent --register
+/etc/init.d/blackfire-agent restart
+
+/bin/bash /run.sh

--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -1,11 +1,12 @@
-FROM php:7.2-fpm
-WORKDIR "/application"
+FROM php:7.2.6-apache-stretch
+
+COPY virtualHost.conf /etc/apache2/sites-enabled/000-a.conf
+
+RUN a2enmod rewrite
 
 # Install git, unzip
 RUN apt-get update \
     && apt-get -y install git unzip vim
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 
 # php-intl (as example of extension)
 RUN apt-get update \
@@ -30,16 +31,8 @@ RUN apt-get update && apt-get install -y libpng-dev libjpeg-dev libpq-dev \
  	&& docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
 	&& docker-php-ext-install gd mbstring pdo pdo_mysql pdo_pgsql
 
-# redis (as example of another extension from downloaded source code)
-RUN curl -L -o /tmp/redis.tar.gz https://github.com/phpredis/phpredis/archive/3.1.6.tar.gz \
-    && tar xfz /tmp/redis.tar.gz \
-    && rm -r /tmp/redis.tar.gz \
-    && mkdir -p /usr/src/php/ext/redis \
-    && mv phpredis-3.1.6/* /usr/src/php/ext/redis/ \
-    && docker-php-ext-install redis
-
 # Fix permission problems
-RUN usermod -u 1000 www-data 
+RUN usermod -u 1000 www-data
 
 RUN echo 'alias ll="ls -l"' >> ~/.bashrc
 RUN echo 'alias sf="php bin/console"' >> ~/.bashrc

--- a/php/virtualHost.conf
+++ b/php/virtualHost.conf
@@ -1,0 +1,20 @@
+<VirtualHost *:80>
+    ServerName localhost
+
+    DocumentRoot /application/public
+
+    <Directory /application/public>
+        Options -Indexes +FollowSymLinks +MultiViews
+        AllowOverride All
+        Require all granted
+    </Directory>
+
+    ErrorLog ${APACHE_LOG_DIR}/example.com-error.log
+
+    # Possible values include: debug, info, notice, warn, error, crit,
+    # alert, emerg.
+    LogLevel warn
+
+    CustomLog ${APACHE_LOG_DIR}/example.com-access.log combined
+
+</VirtualHost>


### PR DESCRIPTION
I always got an mysql connection error until I linked the mysql container in the phpmyadmin and php-fpm configuration.  Also to connect to MySQL from phpmyadmin I needed to pass the enviroment variables PMA_USER PMA_PASSWORD and PMA_HOST

When I linked correctly the containers, the connection was refused by an error about password encryptation. It's seems that mySQL 8 change something about this... so i downgrade to MySQL 5.7 and, finally, all runs fine.

Also I activate an environment selector in .env to run the container in normal mode, with xdebug and with blackfire... and using an alternative container with php and apache2 (sometimes you need check something in apache)