### PR TITLE
Fix host not found on webserver

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,8 @@ services:
           - ${SYMFONY_APP_PATH}:/application
       ports:
        - "8080:80"
+      depends_on:
+       - php-fpm
 
     php-fpm:
       image: php-fpm


### PR DESCRIPTION
Fix error: nginx: [emerg] host not found in upstream "php-fpm" in /etc/nginx/conf.d/default.conf:17